### PR TITLE
fix: method signature

### DIFF
--- a/lib/Wrapper/GroupQuotaWrapper.php
+++ b/lib/Wrapper/GroupQuotaWrapper.php
@@ -22,6 +22,7 @@
 namespace OCA\GroupQuota\Wrapper;
 
 use OC\Files\Storage\Wrapper\Quota;
+use OCP\Files\Cache\ICache;
 
 class GroupQuotaWrapper extends Quota {
 	/** @var int */
@@ -32,7 +33,7 @@ class GroupQuotaWrapper extends Quota {
 		$this->rootSize = $parameters['root_size'];
 	}
 
-	public function getCache($path = '', $storage = null) {
+	public function getCache($path = '', $storage = null): ICache {
 		$parentCache = parent::getCache($path, $storage);
 		return new GroupUsedSpaceCacheWrapper($parentCache, $this->sizeRoot, $this->rootSize);
 	}


### PR DESCRIPTION
After the PR https://github.com/nextcloud/server/pull/48219 the signatore of this method was changed and now is necessary to have return typing.

Problem fixed:

```
Declaration of OCA\\GroupQuota\\Wrapper\\GroupQuotaWrapper::getCache($path = '', $storage = null) must be compatible with OC\\Files\\Storage\\Wrapper\\Wrapper::getCache($path = '', $storage = null): OCP\\Files\\Cache\\ICache at /var/www/html/apps-writable/groupquota/lib/Wrapper/GroupQuotaWrapper.php#35
```

Server version affected: >= 31