### PR TITLE
Fix Call to undefined method OC_Helper::computerFileSize (#82)

### DIFF
--- a/lib/Command/SetQuota.php
+++ b/lib/Command/SetQuota.php
@@ -65,7 +65,7 @@ class SetQuota extends Base {
 			$output->writeln("<error>Group not found: $groupId</error>");
 			return -1;
 		}
-		$quota = \OC_Helper::computerFileSize($input->getArgument('quota'));
+		$quota = \OCP\Util::computerFileSize($input->getArgument('quota'));
 		$this->quotaManager->setGroupQuota($groupId, $quota);
 		if ($input->getOption('format')) {
 			$quota = $quota === FileInfo::SPACE_UNLIMITED ? 'Unlimited' : \OC_Helper::humanFileSize($quota);

--- a/lib/Controller/QuotaController.php
+++ b/lib/Controller/QuotaController.php
@@ -53,7 +53,7 @@ class QuotaController extends OCSController {
 		if (!$group) {
 			throw new OCSBadRequestException('Group not found: ' . $groupId);
 		}
-		$quotaBytes = \OC_Helper::computerFileSize($quota);
+		$quotaBytes = \OCP\Util::computerFileSize($quota);
 		if (!$quotaBytes) {
 			throw new OCSBadRequestException('Invalid quota');
 		}


### PR DESCRIPTION
Fix the issue #82 by replacing `OC_Helper::computerFileSize` with `\OCP\Util::computerFileSize` as the [upgrade log suggest](https://docs.nextcloud.com/server/stable/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.html).