### PR TITLE
Fix Calls to undefined methods OC_Helper::computerFileSize and OC_Helper::humanFileSize for Nextcloud 32

### DIFF
--- a/lib/Command/GetFree.php
+++ b/lib/Command/GetFree.php
@@ -71,7 +71,7 @@ class GetFree extends Base {
 		} else {
 			$used = $this->usedSpaceCalculator->getUsedSpaceByGroup($group);
 			$free = $total_quota - $used;
-			$output->writeln($input->getOption('format') ? \OC_Helper::humanFileSize($free) : (string)$free);
+			$output->writeln($input->getOption('format') ? \OCP\Util::humanFileSize($free) : (string)$free);
 		}
 
 

--- a/lib/Command/GetQuota.php
+++ b/lib/Command/GetQuota.php
@@ -66,7 +66,7 @@ class GetQuota extends Base {
 		}
 		$quota = $this->quotaManager->getGroupQuota($groupId);
 		if ($input->getOption('format')) {
-			$quota = $quota === FileInfo::SPACE_UNLIMITED ? 'Unlimited' : \OC_Helper::humanFileSize($quota);
+			$quota = $quota === FileInfo::SPACE_UNLIMITED ? 'Unlimited' : \OCP\Util::humanFileSize($quota);
 		}
 		$output->writeln($quota);
 

--- a/lib/Command/GetUsed.php
+++ b/lib/Command/GetUsed.php
@@ -64,7 +64,7 @@ class GetUsed extends Base {
 			return -1;
 		}
 		$used = $this->usedSpaceCalculator->getUsedSpaceByGroup($group);
-		$output->writeln($input->getOption('format') ? \OC_Helper::humanFileSize($used) : $used);
+		$output->writeln($input->getOption('format') ? \OCP\Util::humanFileSize($used) : $used);
 
 		return 0;
 	}

--- a/lib/Command/QuotaList.php
+++ b/lib/Command/QuotaList.php
@@ -77,9 +77,9 @@ class QuotaList extends Base {
 			$group = $this->groupManager->get($groupId);
 			$used = $this->usedSpaceCalculator->getUsedSpaceByGroup($group);
 			$free = $quota - $used;
-			$quotaTxt = $input->getOption('format') ? \OC_Helper::humanFileSize($quota) : $quota;
-			$usedTxt = $input->getOption('format') ? \OC_Helper::humanFileSize($used) : $used;
-			$freeTxt = $input->getOption('format') ? \OC_Helper::humanFileSize($free) : $free;
+			$quotaTxt = $input->getOption('format') ? \OCP\Util::humanFileSize($quota) : $quota;
+			$usedTxt = $input->getOption('format') ? \OCP\Util::humanFileSize($used) : $used;
+			$freeTxt = $input->getOption('format') ? \OCP\Util::humanFileSize($free) : $free;
 
 			$texts = [$groupId, $freeTxt, $usedTxt, $quotaTxt];
 			$text = $this->formatTableRow($texts, $widths);

--- a/lib/Command/SetQuota.php
+++ b/lib/Command/SetQuota.php
@@ -68,7 +68,7 @@ class SetQuota extends Base {
 		$quota = \OCP\Util::computerFileSize($input->getArgument('quota'));
 		$this->quotaManager->setGroupQuota($groupId, $quota);
 		if ($input->getOption('format')) {
-			$quota = $quota === FileInfo::SPACE_UNLIMITED ? 'Unlimited' : \OC_Helper::humanFileSize($quota);
+			$quota = $quota === FileInfo::SPACE_UNLIMITED ? 'Unlimited' : \OCP\Util::humanFileSize($quota);
 		}
 		$output->writeln((string)$quota);
 

--- a/lib/Controller/QuotaController.php
+++ b/lib/Controller/QuotaController.php
@@ -75,9 +75,9 @@ class QuotaController extends OCSController {
 	private function buildQuotaResponse(int $quotaBytes, int $used): DataResponse {
 		return new DataResponse([
 			'quota_bytes' => $quotaBytes,
-			'quota_human' => \OC_Helper::humanFileSize($quotaBytes),
+			'quota_human' => \OCP\Util::humanFileSize($quotaBytes),
 			'used_bytes' => $used,
-			'used_human' => \OC_Helper::humanFileSize($used),
+			'used_human' => \OCP\Util::humanFileSize($used),
 			'used_relative' => round((float)$used / (float)$quotaBytes * 100.0, 2)
 		]);
 	}

--- a/tests/stubs/stub.phpstub
+++ b/tests/stubs/stub.phpstub
@@ -230,7 +230,7 @@ namespace OC\Files\Storage {
 }
 
 namespace {
-	class OC_Helper {
+	class OCP\Util {
 		public static function computerFileSize(string $size): int {
 			throw new \Exception('stub');
 		}

--- a/tests/stubs/stub.phpstub
+++ b/tests/stubs/stub.phpstub
@@ -229,8 +229,8 @@ namespace OC\Files\Storage {
 	}
 }
 
-namespace {
-	class OCP\Util {
+namespace OCP{
+	class Util {
 		public static function computerFileSize(string $size): int {
 			throw new \Exception('stub');
 		}


### PR DESCRIPTION
fix the issue in #84 by replacing `OC_Helper` with `OCP\Util` for all mentions of `OC_Helper::computerFileSize` and `OC_Helper::humanFileSize`. See [nextcloud upgrade guide](https://docs.nextcloud.com/server/stable/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_32.html)