### PR TITLE
Fix group quota lookup for users

### DIFF
--- a/lib/Quota/QuotaManager.php
+++ b/lib/Quota/QuotaManager.php
@@ -24,7 +24,6 @@ namespace OCA\GroupQuota\Quota;
 
 use OCP\Files\FileInfo;
 use OCP\IConfig;
-use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 

--- a/lib/Quota/QuotaManager.php
+++ b/lib/Quota/QuotaManager.php
@@ -46,12 +46,10 @@ class QuotaManager {
 
 	public function getUserQuota(IUser $user) {
 		$groups = $this->groupManager->getUserGroups($user);
-		$groupQuotas = array_map(function (IGroup $group) {
-			return $this->getGroupQuota($group->getGID());
-		}, $groups);
-		foreach ($groupQuotas as $group => $quota) {
+		foreach ($groups as $group) {
+			$quota = $this->getGroupQuota($group->getGID());
 			if ($quota >= 0) {
-				return [$group, $quota];
+				return [$group->getGID(), $quota];
 			}
 		}
 		return ['', FileInfo::SPACE_UNLIMITED];


### PR DESCRIPTION
  ## Summary

  Fix group quota resolution for users in `QuotaManager::getUserQuota()`.

  The previous implementation built an array of quotas with `array_map()` and then returned the array index as the group identifier. That index is not the actual group GID, so quota lookup could end up using the
  wrong identifier downstream.

  ## Changes

  - Iterate over the user's groups directly in `getUserQuota()`
  - Return the real group GID alongside the quota
  - Keep the unlimited fallback unchanged

  ## Validation

  - `php -l lib/Quota/QuotaManager.php`
  - Verified the corrected logic in the local Nextcloud environment
  - Confirmed group quotas now resolve to the expected byte value for affected users

  ## Impact

  This restores correct per-group quota application for users who belong to groups managed by `groupquota`.
